### PR TITLE
Fetch puzzle input using scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__
 .python-version
+*/inputs
+*/input

--- a/fetch-calendar
+++ b/fetch-calendar
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+for i in $(seq 1 25)
+do
+  ./fetch-input $1 $i $2
+done
+
+

--- a/fetch-input
+++ b/fetch-input
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+OUTPUT=$3/$(seq -f "%02g" $2 $2).txt
+
+curl \
+  -o $OUTPUT \
+  "https://adventofcode.com/$1/day/$2/input" \
+  --compressed \
+  -H "Cookie: session=$AOCTOKEN" \


### PR DESCRIPTION
- Fetch single puzzle input by year and day.
- Fetch calendar puzzle inputs (1-25) by year.

Requires AOCTOKEN env variable to be set. See adventofcode.com for details.